### PR TITLE
Use mri-stack from TestImages. Fixes #40

### DIFF
--- a/example/volume.jl
+++ b/example/volume.jl
@@ -1,5 +1,11 @@
-using GLPlot, GLVisualize, GLAbstraction, Colors, GeometryTypes, FileIO
-using Reactive, GLWindow, NIfTI
+using GLPlot, GLVisualize, GLAbstraction, Colors, GeometryTypes
+using Reactive, GLWindow
+
+if !isdefined(:vol)
+    using TestImages
+    vol = testimage("mri-stack")
+end
+
 window = GLPlot.init()
 
 layout = [
@@ -8,8 +14,6 @@ layout = [
 ]
 
 screens = GLVisualize.layoutscreens(window, layout)
-vol = niread(joinpath(homedir(), "Desktop", "brain.nii")).raw;
-vol = vol ./ maximum(vol)
 const If0 = GLVisualize.Intensity{1, Float32}
 
 # to change color_map use the interactive edit menu or pass an array of color


### PR DESCRIPTION
Requires https://github.com/JuliaImages/TestImages.jl/pull/29 and https://github.com/JuliaGL/GLVisualize.jl/pull/143. The new file is quite small, so the resolution isn't impressive, but on the other hand the anisotropic pixel spacing represents a good test of functionality that's crucial for almost anyone doing volumetric visualization.
